### PR TITLE
improve j5 node sandbox

### DIFF
--- a/gpio.js
+++ b/gpio.js
@@ -317,7 +317,34 @@ function init(RED) {
                     }
                 },
                 context: {
-                    global:RED.settings.functionGlobalContext || {}
+                    set: function () {
+                        return node.context().set.apply(node, arguments);
+                    },
+                    get: function () {
+                        return node.context().get.apply(node, arguments);
+                    },
+                    get global() {
+                        return node.context().global;
+                    },
+                    get flow() {
+                        return node.context().flow;
+                    }
+                },
+                flow: {
+                    set: function () {
+                        node.context().flow.set.apply(node, arguments);
+                    },
+                    get: function () {
+                        return node.context().flow.get.apply(node, arguments);
+                    }
+                },
+                global: {
+                    set: function () {
+                        node.context().global.set.apply(node, arguments);
+                    },
+                    get: function () {
+                        return node.context().global.get.apply(node, arguments);
+                    }
                 },
                 setTimeout: setTimeout,
                 clearTimeout: clearTimeout,


### PR DESCRIPTION
Howdy,

I found it would be convenient if I could easily store my `board` or other device objects within the `flow` variable available to all "function" node sandboxes.  e.g.:

``` js
// this is a j5 node
const left = new five.Relay({pin: 11, type: 'NC'});

left.on();

const relays = flow.get('relays') || {};
relays.left = left;
flow.set('relays', relays);

node.send({
    payload: {
        relay: 'left'
    }
});
```

Later, a "function" node:

``` js
// this is a plain old function node
const relay = flow.get('relays').left;
const data = msg.payload.data = {};
const isOn = relay.isOn;
data[`${msg.payload.relay}_on`] = isOn;
if (isOn) {
    node.status({fill: 'green', shape: 'dot', text: 'on'});
} else {
    node.status({fill: 'red', shape: 'ring', text: 'off'});
}

return msg;
```

Caveats: 
- this _may_ break compatibility with certain versions of Node-Red, but I couldn't say for sure
- this _may_ break backwards compatibility in general (I'd recommend a "major" bump here)
- the code was mainly copypasta from the core function node source in Node-Red.
