### PR TITLE
add option listen to iot-firmata connect as client

### DIFF
--- a/gpio.html
+++ b/gpio.html
@@ -101,7 +101,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
       <label for="node-config-input-connectionType"><i class="fa fa-wrench"></i> Connection</label>
       <select type="text" id="node-config-input-connectionType" style="width: 200px;">
           <option value="local">Local Serial Port</option>
-          <option value="tcp">TCP Socket</option>
+          <option value="tcp">TCP Connect to</option>
+          <option value="tcplisten">TCP Listen on</option>
           <option value="udp">UDP broadcast</option>
           <option value="socketio">socket.io</option>
           <option value="mqtt">MQTT</option>
@@ -420,6 +421,7 @@ RED.nodes.registerType('gpio in',{
         meshblu: ['meshbluServer', 'uuid', 'token', 'sendUuid'],
         socketio: ['socketServer', 'pub', 'sub'],
         tcp: ['tcpHost', 'tcpPort'],
+        tcplisten: ['tcpPort'],
         udp: ['tcpHost', 'tcpPort']
       };
 

--- a/gpio.js
+++ b/gpio.js
@@ -22,7 +22,7 @@ var util = require('util');
 var _ = require('lodash');
 
 function connectingStatus(n){
-  n.status({fill:"red",shape:"ring",text:"connecting"});
+  n.status({fill:"red",shape:"ring",text:"connecting ... "});
 }
 
 function networkReadyStatus(n){
@@ -39,7 +39,7 @@ function ioErrorStatus(n, err){
 }
 
 function connectedStatus(n){
-  n.status({fill:"green",shape:"dot",text:"connected"});
+  n.status({fill:"green",shape:"dot",text:"connected !!!! "});
 }
 
 
@@ -109,8 +109,9 @@ function init(RED) {
         connectingStatus(node);
 
         node.nodebot.on('ioready', function() {
-            connectedStatus(node);
 
+            connectedStatus(node);
+            
             node.on('input', function(msg) {
               try{
                 var state = msg.state || node.state;
@@ -251,7 +252,6 @@ function init(RED) {
         node.nodebot.on('ioready', function() {
           // console.log('launching johnny5Node ioready', n);
             connectedStatus(node);
-
 
             function sendResults(node,msgs) {
                 var _msgid = (1 + Math.random() * 4294967295).toString(16);

--- a/lib/nodebotNode.js
+++ b/lib/nodebotNode.js
@@ -181,6 +181,23 @@ function createNode(RED){
           });
         }
       }
+	else if(n.connectionType === 'tcplisten'){ //mode listen network
+
+      	net.createServer(function(socket){
+      		node.io = new firmata.Board(socket);
+      		start(node);
+      		  console.log('client ready', socket.remoteAddress + ":" + socket.remotePort );
+           	socket.emit('open', {});
+  		      socket.on('error', function(err){
+      		  console.log('tcp error', err);
+      		  node.warn(err);
+      		  process.nextTick(function() {
+      		    node.emit('networkError', err);
+      		  });
+      		});
+      	}).listen(parseInt(n.tcpPort, 10));
+
+      }
       else if(n.connectionType === 'tcp'){
         //console.log('trying', n.tcpHost, n.tcpPort);
         var options = {


### PR DESCRIPTION
I realized the need to connect a device IOT on a gateway and put that RED plug-in listen mode.
So, I added an option to connect my ESP8266-01 with standard firmware and core Arduino with Firmata as protocol. It worked.
